### PR TITLE
fixed nested router-view bug.

### DIFF
--- a/src/api/router-cache.js
+++ b/src/api/router-cache.js
@@ -15,10 +15,25 @@ const routerCache = {
       const globalCacheItem = globalCache[i]
       const cache = globalCacheItem.cache
       if (cache[removeItem]) {
-        cache[removeItem].componentInstance.$destroy()
+        this._destroyGuard(cache, removeItem) && cache[removeItem].componentInstance.$destroy()
         cache[removeItem] = null
       }
     }
+  },
+  _destroyGuard(cache, removeKey) {
+    const removeVnode = cache[removeKey]
+    const getVnodeKey = vnode => {
+      const componentOptions = vnode.componentOptions
+      const key = vnode.key == null ? componentOptions.Ctor.cid + (componentOptions.tag ? `::${componentOptions.tag}` : '') : vnode.key
+      return key
+    }
+    const removeVnodeKey = getVnodeKey(removeVnode)
+    for (const key in cache) {
+      if (getVnodeKey(cache[key]) === removeVnodeKey && key !== removeKey) {
+        return false
+      }
+    }
+    return true
   },
   removeGlobalCacheFromList(removeList) {
     for (let i = 0; i < removeList.length; i++) {


### PR DESCRIPTION
router-cache使用$route的name作为cache 的key，如果是嵌套路由的情况，所有嵌套路由的$route key指向的都是一级路由的vnode，此时如果返回的话，会$destroy掉还存在引用的vnode，造成页面假死。